### PR TITLE
Add SRI integrity hash to federation stats JSON

### DIFF
--- a/packages/loadable-adapters/src/extract-federated-chunks/extract-federated-chunks.ts
+++ b/packages/loadable-adapters/src/extract-federated-chunks/extract-federated-chunks.ts
@@ -90,7 +90,7 @@ export function extractFederatedChunks(
         return;
       }
       const remoteStats = mfChunks.find((remote) => remote.name === appName);
-      remoteStats.exposes[component].forEach((chunk: string) => {
+      remoteStats.exposes[component].forEach(({ chunk }: { chunk: string }) => {
         const url = `${mfPublicHost[appName]}/${chunk}`;
 
         // eslint-disable-next-line no-unused-expressions

--- a/packages/loadable-adapters/src/federation-stats-plugin/federation-stats-plugin.js
+++ b/packages/loadable-adapters/src/federation-stats-plugin/federation-stats-plugin.js
@@ -122,7 +122,9 @@ export class FederationStatsPlugin {
           const fileName = this._options.fileName;
           const statsFilePath = path.join(compiler.options.output.path, fileName);
 
-          if (!fs.existsSync(statsFilePath)) return;
+          if (!fs.existsSync(statsFilePath)) {
+            throw new Error(`[${PLUGIN_NAME}] ${fileName} file not found.`);
+          }
 
           const rawMfStats = fs.readFileSync(statsFilePath, 'utf-8');
 

--- a/packages/loadable-adapters/src/federation-stats-plugin/federation-stats-plugin.js
+++ b/packages/loadable-adapters/src/federation-stats-plugin/federation-stats-plugin.js
@@ -121,8 +121,17 @@ export class FederationStatsPlugin {
         compiler.hooks.afterDone.tap(PLUGIN_NAME, () => {
           const fileName = this._options.fileName;
           const statsFilePath = path.join(compiler.options.output.path, fileName);
+
+          if (!fs.existsSync(statsFilePath)) return;
+
           const rawMfStats = fs.readFileSync(statsFilePath, 'utf-8');
-          const mfStats = JSON.parse(rawMfStats);
+
+          let mfStats;
+          try {
+            mfStats = JSON.parse(rawMfStats);
+          } catch (error) {
+            throw new Error(`[${PLUGIN_NAME}] Error parsing ${fileName} file.`);
+          }
 
           Object.entries(mfStats.exposes).forEach(([key, value]) => {
             mfStats.exposes[key] = value.map((v) => {

--- a/packages/loadable-adapters/src/federation-stats-plugin/federation-stats-plugin.js
+++ b/packages/loadable-adapters/src/federation-stats-plugin/federation-stats-plugin.js
@@ -114,7 +114,7 @@ export class FederationStatsPlugin {
             .forEach((asset) => {
               const integrity = Array.isArray(asset.integrity) ? asset.integrity[0] : asset.integrity;
               console.log(asset.name, integrity);
-              assetIntegrityMap.set(asset.name, integrity.split(' ')[0]);
+              assetIntegrityMap.set(asset.name, integrity);
             });
         });
 

--- a/packages/loadable-adapters/src/federation-stats-plugin/federation-stats-plugin.js
+++ b/packages/loadable-adapters/src/federation-stats-plugin/federation-stats-plugin.js
@@ -59,7 +59,6 @@ export class FederationStatsPlugin {
             return {
               module: exposedAs,
               chunks: chunks,
-              id: module.id,
             };
           });
 
@@ -68,7 +67,6 @@ export class FederationStatsPlugin {
               Object.assign(result, {
                 [current.module.replace('./', '')]: current.chunks.map((chunk) => ({
                   chunk,
-                  id: current.id,
                 })),
               }),
             {}

--- a/packages/loadable-adapters/src/federation-stats-plugin/readme.md
+++ b/packages/loadable-adapters/src/federation-stats-plugin/readme.md
@@ -18,12 +18,35 @@ As an option you could provide a output file name
   "name": "AppName",
   "exposes": {
     "module1": [
-      "vendors-node_modules_babel_runtime_helpers_esm_slicedToArray.js",
-      "vendors-node_modules_core-js.js",
-      "vendors-node_modules_prop-types_index_js.js"
+      {
+        "chunk": "vendors-node_modules_babel_runtime_helpers_esm_slicedToArray.js",
+        "integrity": "sha256-6ztd5MP6NcgnUXeP3xulOfEGhJg3qlFu7ztMGaGaj3Q="
+      },
+      {
+        "chunk": "vendors-node_modules_core-js.js",
+        "integrity": "sha384-v0xgYodEvbgtfRPNinFTbTlRUvWfHSCU4LhxlYnulu6eKSAo4A95Uw/l5cLfo2ra"
+      },
+      {
+        "chunk": "vendors-node_modules_prop-types_index_js.js",
+        "integrity": "sha512-O4tsGm/weU4T1hL1szM0E2M/4k7dj0x/I9rmserP99LxYS1492/d5VRPg0tajOtWIPzMoCxvfkr37/mOUwZgBg=="
+      }
     ],
-    "module2": ["vendors-node_modules_core-js.js"],
-    "module3": ["vendors-node_modules_babel.js", "vendors-node_modules_core-js.js"]
+    "module2": [
+      {
+        "chunk": "vendors-node_modules_core-js.js",
+        "integrity": "sha384-v0xgYodEvbgtfRPNinFTbTlRUvWfHSCU4LhxlYnulu6eKSAo4A95Uw/l5cLfo2ra"
+      }
+    ],
+    "module3": [
+      {
+        "chunk": "vendors-node_modules_babel.js",
+        "integrity": "sha256-6ztd5MP6NcgnUXeP3xulOfEGhJg3qlFu7ztMGaGaj3Q="
+      },
+      {
+        "chunk": "vendors-node_modules_core-js.js",
+        "integrity": "sha384-v0xgYodEvbgtfRPNinFTbTlRUvWfHSCU4LhxlYnulu6eKSAo4A95Uw/l5cLfo2ra"
+      }
+    ]
   }
 }
 ```


### PR DESCRIPTION
This PR aims to add support for [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity).

This will append the integrity information of chunk the generated stats json file whenever the plugin is being used in the project.
